### PR TITLE
brew cite: add --recursive option

### DIFF
--- a/cmd/brew-cite.rb
+++ b/cmd/brew-cite.rb
@@ -51,13 +51,18 @@ module Homebrew
     cite_url "https://doi.org/#{doi}"
   end
 
-  def cite_formula(name)
+  def cite_formula(name, follow = true)
     formula = Formula[name]
     matches = formula.path.read.scan /# cite .*"(.*)"/
     if matches.empty?
       opoo "#{formula.full_name}: No citation"
     else
       matches.each { |match| cite_url match[0] }
+    end
+    if args.recursive? and follow
+      formula.deps.each do |dep|
+        cite_formula dep.name, false
+      end
     end
   end
 
@@ -76,6 +81,7 @@ module Homebrew
     Homebrew::CLI::Parser.parse do
       switch "--bib"
       switch "--doi"
+      switch "--recursive"
       switch "--ruby"
       switch "--text"
       switch "--url"


### PR DESCRIPTION
Example output:
```
 ❯ brew cite --recursive prokka
@article{Seemann_2014, title={Prokka: rapid prokaryotic genome annotation}, volume={30}, ISSN={1460-2059}, url={http://dx.doi.org/10.1093/bioinformatics/btu153}, DOI={10.1093/bioinformatics/btu153}, number={14}, journal={Bioinformatics}, publisher={Oxford University Press (OUP)}, author={Seemann, T.}, year={2014}, month={Mar}, pages={2068–2069}}
@article{Laslett_2004, title={ARAGORN, a program to detect tRNA genes and tmRNA genes in nucleotide sequences}, volume={32}, ISSN={1362-4962}, url={http://dx.doi.org/10.1093/nar/gkh152}, DOI={10.1093/nar/gkh152}, number={1}, journal={Nucleic Acids Research}, publisher={Oxford University Press (OUP)}, author={Laslett, D.}, year={2004}, month={Jan}, pages={11–16}}
@article{Stajich_2002, title={The Bioperl Toolkit: Perl Modules for the Life Sciences}, volume={12}, ISSN={1088-9051}, url={http://dx.doi.org/10.1101/gr.361602}, DOI={10.1101/gr.361602}, number={10}, journal={Genome Research}, publisher={Cold Spring Harbor Laboratory}, author={Stajich, J. E.}, year={2002}, month={Oct}, pages={1611–1618}}
@article{Nawrocki_2009, title={Infernal 1.0: inference of RNA alignments}, volume={25}, ISSN={1460-2059}, url={http://dx.doi.org/10.1093/bioinformatics/btp157}, DOI={10.1093/bioinformatics/btp157}, number={10}, journal={Bioinformatics}, publisher={Oxford University Press (OUP)}, author={Nawrocki, E. P. and Kolbe, D. L. and Eddy, S. R.}, year={2009}, month={Mar}, pages={1335–1337}}
@article{Bland_2007, title={CRISPR Recognition Tool (CRT): a tool for automatic detection of clustered regularly interspaced palindromic repeats}, volume={8}, ISSN={1471-2105}, url={http://dx.doi.org/10.1186/1471-2105-8-209}, DOI={10.1186/1471-2105-8-209}, number={1}, journal={BMC Bioinformatics}, publisher={Springer Science and Business Media LLC}, author={Bland, Charles and Ramsey, Teresa L and Sabree, Fareedah and Lowe, Micheal and Brown, Kyndall and Kyrpides, Nikos C and Hugenholtz, Philip}, year={2007}, month={Jun}}
Warning: Missing citations for the following formulae:
  brewsci/bio/barrnap
  blast
  hmmer
  parallel
  prodigal
  brewsci/bio/tbl2asn
```

I'm also thinking that the warnings for the missing citation should be collected and displayed at the end.