### PR TITLE
.github: Use Docker image homebrew/ubuntu16.04

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -16,7 +16,7 @@ jobs:
   build-linux-bottles:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04
     steps:
       - uses: actions/checkout@master
       - name: Build bottles

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -8,7 +8,7 @@ jobs:
   upload-bottles:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brew
+      image: homebrew/ubuntu16.04
     env:
       HOMEBREW_BINTRAY_USER: linuxbrewtestbot
       HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}


### PR DESCRIPTION
Use Docker image homebrew/ubuntu16.04 rather than homebrew/brew.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-base/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-base/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?